### PR TITLE
Perform a no-op if Node was not installed by the Heroku buildpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,97 +1,24 @@
-const http = require('http');
-const https = require('https');
-const url = require('url');
 const util = require('util');
-const { Histogram } = require("measured");
-const nativeStats = require('./nativeStats');
-
 const log = util.debuglog('heroku');
-const METRICS_INTERVAL = parseInt(process.env.METRICS_INTERVAL_OVERRIDE, 10) || 20000; // 20 seconds
 
-// Set a minimum of 10 seconds
-if (METRICS_INTERVAL < 10000) {
-  METRICS_INTERVAL = 10000;
+// if the node version does not match the major version, bail
+const match = process.version.match(/^v([0-9]+)/);
+const isExpectedNodeVersion = match && match[1] === NODE_MAJOR_VERSION;
+
+// if we are not using node installed by the Heroku buildpack, bail
+const isExpectedNodePath = process.execPath === "/app/.heroku/node/bin/node";
+
+if (isExpectedNodeVersion && isExpectedNodePath) {
+  const start = require('./monitor.js');
+  start();
+} else {
+  if (!isExpectedNodePath) {
+    log("[heroku-nodejs-plugin] expected different Node path. Found:", process.execPath);
+  }
+  if (!isExpectedNodeVersion) {
+    log("[heroku-nodejs-plugin] expected different Node version. Expected:",
+    NODE_MAJOR_VERSION,
+    "Found:",
+    match && match[1]);
+  }
 }
-
-// Collects the event loop ticks, and calculates p50, p95, p99, max
-let delay = new Histogram();
-
-// url is where the runtime metrics will be posted to. This is added
-// to dynos by runtime iff the app is opped into the heroku runtime metrics
-// beta.
-let uri = url.parse(process.env.HEROKU_METRICS_URL);
-
-nativeStats.start();
-
-function submitData(data, cb) {
-  const postData = JSON.stringify(data);
-
-  // post data to metricsURL
-  const options = {
-    method: "POST",
-    protocol: uri.protocol,
-    hostname: uri.hostname,
-    port: uri.port,
-    path: uri.path,
-    headers: {
-      "Content-Type": "application/json",
-      "Content-Length": Buffer.byteLength(postData),
-    },
-  };
-
-  const request = uri.protocol === 'https:' ? https.request : http.request;
-  const req = request(options, res => cb(null, res));
-  req.on('error', cb);
-  req.write(postData);
-  req.end();
-}
-
-// every METRICS_INTERVAL seconds, submit a metrics payload to metricsURL.
-setInterval(() => {
-  let { ticks, gcCount, gcTime, oldGcCount, oldGcTime, youngGcCount, youngGcTime } = nativeStats.sense();
-  let totalEventLoopTime = ticks.reduce((a, b) => a + b, 0);
-
-  ticks.forEach(tick => delay.update(tick));
-
-  let aa = totalEventLoopTime / METRICS_INTERVAL;
-
-  let { median, p95, p99, max } = delay.toJSON();
-
-  let data = {
-    counters: {
-      "node.gc.collections": gcCount,
-      "node.gc.pause.ns": gcTime,
-      "node.gc.old.collections": oldGcCount,
-      "node.gc.old.pause.ns": oldGcTime,
-      "node.gc.young.collections": youngGcCount,
-      "node.gc.young.pause.ns": youngGcTime,
-    },
-    gauges: {
-      "node.eventloop.usage.percent": aa,
-      "node.eventloop.delay.ms.median": median,
-      "node.eventloop.delay.ms.p95": p95,
-      "node.eventloop.delay.ms.p99": p99,
-      "node.eventloop.delay.ms.max": max
-    }
-  };
-
-  submitData(data, (err, res) => {
-    if (err !== null) {
-      log(
-        "[heroku-nodejs-plugin] error when trying to submit data: ",
-        err
-      );
-      return;
-    }
-
-    if (res.statusCode !== 200) {
-      log(
-        "[heroku-nodejs-plugin] expected 200 when trying to submit data, got:",
-        res.statusCode
-      );
-      return;
-    }
-  });
-
-  delay.reset();
-}, METRICS_INTERVAL).unref();

--- a/src/monitor.js
+++ b/src/monitor.js
@@ -1,0 +1,102 @@
+const http = require('http');
+const https = require('https');
+const url = require('url');
+const util = require('util');
+const { Histogram } = require("measured");
+const nativeStats = require('./nativeStats');
+
+// url is where the runtime metrics will be posted to. This is added
+// to dynos by runtime iff the app is opped into the heroku runtime metrics
+// beta.
+let uri = url.parse(process.env.HEROKU_METRICS_URL);
+
+function submitData(data, cb) {
+  const postData = JSON.stringify(data);
+
+  // post data to metricsURL
+  const options = {
+    method: "POST",
+    protocol: uri.protocol,
+    hostname: uri.hostname,
+    port: uri.port,
+    path: uri.path,
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(postData),
+    },
+  };
+
+  const request = uri.protocol === 'https:' ? https.request : http.request;
+  const req = request(options, res => cb(null, res));
+  req.on('error', cb);
+  req.write(postData);
+  req.end();
+}
+
+function start() {
+  const log = util.debuglog('heroku');
+
+  const METRICS_INTERVAL = parseInt(process.env.METRICS_INTERVAL_OVERRIDE, 10) || 20000; // 20 seconds
+
+  // Set a minimum of 10 seconds
+  if (METRICS_INTERVAL < 10000) {
+    METRICS_INTERVAL = 10000;
+  }
+
+  // Collects the event loop ticks, and calculates p50, p95, p99, max
+  let delay = new Histogram();
+
+  nativeStats.start();
+
+  // every METRICS_INTERVAL seconds, submit a metrics payload to metricsURL.
+  setInterval(() => {
+    let { ticks, gcCount, gcTime, oldGcCount, oldGcTime, youngGcCount, youngGcTime } = nativeStats.sense();
+    let totalEventLoopTime = ticks.reduce((a, b) => a + b, 0);
+
+    ticks.forEach(tick => delay.update(tick));
+
+    let aa = totalEventLoopTime / METRICS_INTERVAL;
+
+    let { median, p95, p99, max } = delay.toJSON();
+
+    let data = {
+      counters: {
+        "node.gc.collections": gcCount,
+        "node.gc.pause.ns": gcTime,
+        "node.gc.old.collections": oldGcCount,
+        "node.gc.old.pause.ns": oldGcTime,
+        "node.gc.young.collections": youngGcCount,
+        "node.gc.young.pause.ns": youngGcTime,
+      },
+      gauges: {
+        "node.eventloop.usage.percent": aa,
+        "node.eventloop.delay.ms.median": median,
+        "node.eventloop.delay.ms.p95": p95,
+        "node.eventloop.delay.ms.p99": p99,
+        "node.eventloop.delay.ms.max": max
+      }
+    };
+
+    submitData(data, (err, res) => {
+      if (err !== null) {
+        log(
+          "[heroku-nodejs-plugin] error when trying to submit data: ",
+          err
+        );
+        return;
+      }
+
+      if (res.statusCode !== 200) {
+        log(
+          "[heroku-nodejs-plugin] expected 200 when trying to submit data, got:",
+          res.statusCode
+        );
+        return;
+      }
+    });
+
+    delay.reset();
+  }, METRICS_INTERVAL).unref();
+}
+
+module.exports = start;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 let webpack = require('webpack');
 let path = require('path');
 
+let match = process.version.match(/^v([0-9]+)/);
+
 module.exports = {
     // Don't minify the output script
     mode: 'none',
@@ -14,5 +16,13 @@ module.exports = {
 
         // Make sure the output file is named `index.js`
         filename: 'index.js',
-    }
+    },
+    plugins: [
+        new webpack.DefinePlugin({
+            // Save the major version of Node that the plugin was compiled with
+            // so that the plugin can perform a no-op when included in a different
+            // version of Node
+            NODE_MAJOR_VERSION: `"${match[1]}"`,
+        }),
+    ]
 };


### PR DESCRIPTION
On rare instances, a Heroku user may install their own version of Node outside of the Node buildpack, ex: the Heroku CLI contains its own version of Node which might not match the version installed via the buildpack.

In this case, this version of Node would pick up the additional --require statement in NODE_OPTIONS and include a native module compiled for a different Node version and fail.

This commit adds some additional checks to make sure that the Node major version matches the version the plugin was compiled for, and that the Node executable is the one installed by the Node Buildpack. If either is not true, this module becomes a no-op.