### PR TITLE
add Node 14 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- '8'
-- '9'
 - '10'
-- '11'
 - '12'
 - '13'
 - '14'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
 - '11'
 - '12'
 - '13'
+- '14'
 addons:
   apt:
     sources:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Plugin Changelog
 
 ## master
+- Add Node 14 to releases ([#18](https://github.com/heroku/heroku-nodejs-plugin/pull/18))
 
 ## v6 (2019-10-23)
 - Add Node 13 to releases ([#11](https://github.com/heroku/heroku-nodejs-plugin/pull/11))


### PR DESCRIPTION
Also removes builds for Node 8, 9, and 11 since they are deprecated.