### PR TITLE
Fix bug with ES module usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 build
 heroku-nodejs-plugin
 .vscode
+*.tar.gz
+*.sha512

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Node.js Plugin Changelog
 
 ## master
+- Specify `commonjs` module usage for app usage ([#30](https://github.com/heroku/heroku-nodejs-plugin/pull/30))
 
 ## v8 (2020-10-21)
 - Update elliptic package ([#23](https://github.com/heroku/heroku-nodejs-plugin/pull/23))

--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,11 @@
 			"dependencies": ["heroku-nodejs-plugin"],
 			"copies": [
 				{
-					"files": ["./build/Release/heroku-nodejs-plugin.node"],
+					"files": [
+						"./src/README.md",
+						"./build/Release/heroku-nodejs-plugin.node",
+						"./package.json"
+					],
 					"destination": "./heroku-nodejs-plugin/"
 				}
 			]

--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,4 @@ npx node-gyp configure build
 # roll the javascript into one file
 npx webpack-cli
 
-# copy over the README
-cp ./src/README.md ./heroku-nodejs-plugin/README.md
-
 echo "Successfully built plugin"

--- a/package.json
+++ b/package.json
@@ -17,5 +17,6 @@
     "webpack-cli": "^3.3.11"
   },
   "license": "MIT",
-  "repository": "https://github.com/heroku/heroku-nodejs-plugin"
+  "repository": "https://github.com/heroku/heroku-nodejs-plugin",
+  "type": "commonjs"
 }


### PR DESCRIPTION
Fixes: https://github.com/heroku/heroku-nodejs-plugin/issues/22.

Adds `commonjs` as the type for this module. The `package.json` is copied over at build time and made available when the Node process starts.