### PR TITLE
Rename plugin to have expected directory name [changelog skip]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,11 @@ jobs:
           name: Install dependencies
           command: npm install --ignore-scripts
       - run:
+          name: Make plugin directory
+          command: mkdir heroku-nodejs-plugin
+      - run:
           name: Copy plugin to workspace
-          command: cp -r /tmp/workspace/heroku-nodejs-plugin-<< parameters.node-version >> .
+          command: cp -r /tmp/workspace/heroku-nodejs-plugin-<< parameters.node-version >>/* heroku-nodejs-plugin
       - run:
           name: Run deploy script
           command: ./scripts/upload-assets.sh << parameters.node-version >>


### PR DESCRIPTION
Originally I had changed the name of the directory the plugin got built in, so it didn't collide in the CI job. Downstream, that has caused some tests to break on the buildpack, and it could break other dependencies, so I am changing the name of the directory to the expected name `heroku-nodejs-plugin` right before it gets compressed.