### PR TITLE
Reduce Dependabot frequency and enable for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Reduce the frequency to reduce the churn + email notification noise slightly. GitHub will still open PRs for any security issues outside of the monthly cadence.

Also enables Dependabot for GitHub Actions, now that this repo is using it instead of Circle CI, for parity with our other Actions-using repositories.