### PR TITLE
Build plugins for Node.js 19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: ["14", "16", "18"]
+        node-version: ["14", "16", "18", "19"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: ["14", "16", "18"]
+        node-version: ["14", "16", "18", "19"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     strategy:
       matrix:
-        node-version: ["14", "16", "18"]
+        node-version: ["14", "16", "18", "19"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## main
 
+## v11 (2022-10-19)
+- Add Node 19. ([#85](https://github.com/heroku/heroku-nodejs-plugin/pull/85))
 - Convert to GitHub Actions. Drop Node 17. ([#79](https://github.com/heroku/heroku-nodejs-plugin/pull/79))
 
 ## v10 (2022-05-23)


### PR DESCRIPTION
Node.js 19.0.0 was released on 2022-10-18 (ref: [Node.js releases](https://nodejs.dev/en/about/releases/)). We should make the metrics plugin available for the 19.x line.

[W-11932999](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000019GHxdYAG)