### PR TITLE
Build plugins for Node.js 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: ["14", "16", "18", "19"]
+        node-version: ["14", "16", "18", "19", "20"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: ["14", "16", "18", "19"]
+        node-version: ["14", "16", "18", "19", "20"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -83,7 +83,7 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
     strategy:
       matrix:
-        node-version: ["14", "16", "18", "19"]
+        node-version: ["14", "16", "18", "19", "20"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## main
 
+## v12 (2023-04-19)
+- Add Node 20. ([#86](https://github.com/heroku/heroku-nodejs-plugin/pull/86))
+
 ## v11 (2022-10-19)
 - Add Node 19. ([#85](https://github.com/heroku/heroku-nodejs-plugin/pull/85))
 - Convert to GitHub Actions. Drop Node 17. ([#79](https://github.com/heroku/heroku-nodejs-plugin/pull/79))


### PR DESCRIPTION
Node.js 20.0.0 was released on 2023-04-18 (ref: [Node.js releases](https://nodejs.dev/en/about/releases/)). We should make the metrics plugin available for the 20.x line.

[W-13066983](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001PnvKgYAJ/view)