### PR TITLE
Fix automation to use IP-allowed runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   release:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: pub-hk-ubuntu-22.04-small
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
@@ -78,7 +78,7 @@ jobs:
   upload:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs: release
-    runs-on: ubuntu-22.04
+    runs-on: pub-hk-ubuntu-22.04-small
     env:
       GITHUB_TOKEN: ${{ github.token }}
     strategy:


### PR DESCRIPTION
The Heroku GitHub org uses an IP allowlist. A runner from that allowlist is required in order to meet IP requirements.

[W-13066983](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001PnvKgYAJ/view)