### PR TITLE
Update version to match npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heroku-nodejs-plugin",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "A module that forwards stats from a Node process into the Heroku metrics system",
   "scripts": {
     "postinstall": "./scripts/build.sh",


### PR DESCRIPTION
This package is not actively published to npm.  Instead, new [releases](https://github.com/heroku/heroku-nodejs-plugin/releases) are versioned incrementally (`v11`, `v12`, `v13`, ...) and added as vendored packages to the [heroku/nodejs](https://github.com/heroku/heroku-buildpack-nodejs) buildpack.

But:
* we did publish a single release to npm so that the name `heroku-nodejs-plugin` in order to claim this package name and prevent some other malicious package from publishing under this name
* this published version is reported as `0.1.3`

This can cause some confusion because the version for this package in the `main` branch is `0.1.0` which does not match the version published to npm (`0.1.3`).  Furthermore, there is an [outdated Synk vulnerability report for `heroku-nodejs-plugin@0.1.0` ](https://security.snyk.io/vuln/SNYK-JS-HEROKUNODEJSPLUGIN-2934433) that adds to the confusion around this package.

Bumping the current version on `main` to `0.1.3` would at least align the valid package we have on npm with this repository (even if we don't plan to publish newer versions there) and avoid matching the same version in the outdated Synk report.

Going forward we should revisit:
* the use of incremental versioning instead of semver so that we could have a version listed in package.json that is consistent
* publishing new versions to npm even if we still vendor them into the [heroku/nodejs](https://github.com/heroku/heroku-buildpack-nodejs) buildpack