### PR TITLE
fix(socket-leak): fixing socket leak for node 19+

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -78,6 +78,13 @@ function start() {
     };
 
     submitData(data, (err, res) => {
+      // We don't ever read the body of the response, just the status code to ensure it is 200.
+      // As a result, we need to instruct node that we won't be using the body so that it can
+      // close out the connection. This is particularly important as in node 19+, http connections
+      // now default to `Connection: keep-alive` and if we don't call res.resume() then the socket
+      // for each metrics post request will be left alive and effectively causes a memory leak.
+      res.resume();
+
       if (err !== null) {
         log(
           "[heroku-nodejs-plugin] error when trying to submit data: ",


### PR DESCRIPTION
We have been noticing that after updating to the node 20 LTS that there is a slow persistent memory leak that happens over the course of the day until the next daily restart gets triggered. This was true even for a simple nodejs web-service that does nothing but provide a `/healthcheck` endpoint which responds with `statusCode` 200 that gets called once a minute.

![image](https://github.com/heroku/heroku-nodejs-plugin/assets/17907922/e4be6ceb-588a-4ee5-a8eb-89da008f9895)

After capturing heap snapshots over the course of the day, it became pretty clear that the leak was a bunch of `ClientRequest`, `IncomingMessage`, and `Sockets` which all had roughly the same count and amounted to one every 20 seconds or so, and correspond to the `http://localhost:1337/metrics` post requests made by this plugin.

![image](https://github.com/heroku/heroku-nodejs-plugin/assets/17907922/3cc88468-1ee0-496d-b68f-d821c9162b89)

Having identified _what_ was leaking, I then needed to track down _why_ this code is leaking sockets. It turns out that starting in node 19, `keep-alive` is now the default for the http/https `globalAgent` (see https://nodejs.org/en/blog/announcements/v19-release-announce#https11-keepalive-by-default). This change appears to have the potential to leave sockets open in some specific circumstances which we are running into in this plugin. After experimentation, it seems as though the requirements for the socket leak are as follows:

1. The request needs to write to the body using `req.write(content)`, or `req.end(content)`
2. The server must respond with `Connection: keep-alive` or omit the `Connection` header (since its now assumed by default).
3. You have a response callback (either passed into the request or through `req.once('reponse', callback)`)
4. In that response callback, you are only checking things like statusCode, but not actually consuming the response body with `res.on('data', ...)`, or `[res.resume()](https://nodejs.org/api/stream.html#readableresume)`. The `node:http` documentation does also mention using `res.resume()`, but it mostly seems to be mentioned in passing as a memory optimization as the memory associated with the body (if there is one) could possibly be discarded sooner than if waiting for GC to collect it. It seems like with this recent node change it might become more important.

Since we don't really have much choice regarding points 1-2, and we presumably need to check for non-200 `statusCode`'s, the only real option that presented itself was to call `res.resume()` in the response callback to consume the body and thus close the request. Once the request is closed, the socket goes back to the `globalAgent.freeSocket` pool and can be re-used by a future request.

Note: This doesn't actually confer much benefit in this case since the default timeout for the `globalAgent` is 5 seconds and the minimum interval for metrics updates is 10 seconds. While you could technically make the requests with a custom agent with a timeout large enough to accommodate `METRICS_INTERVAL`, it isn't really worth it since reporting metrics every 20 seconds or so isn't really the sort of thing where the latency of re-establishing the connection to localhost matters very much :)