### PR TITLE
Ensure res is defined before calling res.resume()

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -83,7 +83,9 @@ function start() {
       // close out the connection. This is particularly important as in node 19+, http connections
       // now default to `Connection: keep-alive` and if we don't call res.resume() then the socket
       // for each metrics post request will be left alive and effectively causes a memory leak.
-      res.resume();
+      if (res) {
+        res.resume();
+      }
 
       if (err !== null) {
         log(


### PR DESCRIPTION
My colleague Cynthia noticed this recent change to the plugin.

In production we are seeing multiple apps crashing because `res` is undefined.

This is a speculative fix which probably needs more work from someone who knows a lot more about this plugin than me.

We have [ticket 1324529](https://help.heroku.com/1324529) open for this issue.